### PR TITLE
Rp 7 motpars

### DIFF
--- a/brainsss2/motion_correction.py
+++ b/brainsss2/motion_correction.py
@@ -284,8 +284,7 @@ def run_motion_correction(args, files, h5_files):
         if args.stepsize > 1:
             mytx = ants.motion_correction(image=chunkdata_ants, fixed=ch1_meanbrain,
                 verbose=args.verbose, type_of_transform=args.type_of_transform,
-                total_sigma=args.total_sigma, flow_sigma=args.flow_sigma,
-                outprefix=os.path.join(args.temp_dir, f'moco_chunk_{i}_'))
+                total_sigma=args.total_sigma, flow_sigma=args.flow_sigma)
 
             assert mytx is not None, 'ants.motioncorrection failed'
             step_transforms = mytx['motion_parameters']

--- a/brainsss2/settings/settings.json
+++ b/brainsss2/settings/settings.json
@@ -13,6 +13,7 @@
     "motion_correction_func": {
         "script": "motion_correction.py",
         "type_of_transform": "SyN",
+        "stepsize": 1,
         "time_hours": 24,
         "dirtype": "func"
     },
@@ -20,7 +21,7 @@
         "script": "motion_correction.py",
         "type_of_transform": "SyN",
         "time_hours": 8,
-        "stepsize": 4,
+        "stepsize": 1,
         "downsample": true,
         "dirtype": "anat"
     },

--- a/scripts/extend_motpars.py
+++ b/scripts/extend_motpars.py
@@ -1,0 +1,28 @@
+# create extended motion parameters
+
+import sys
+import os
+from brainsss2.argparse_utils import get_base_parser # noqa
+from brainsss2.motion_correction import extend_motpars
+
+
+def parse_args(input, allow_unknown=True):
+    parser = get_base_parser('extend motion parameters')
+
+    parser.add_argument('-f', '--file', type=str,
+        help='motion parameter file to process', required=True)
+    parser.add_argument('--outfile', type=str,
+        help='output file name (defaults to <file>_extended.txt)')
+    if allow_unknown:
+        args, unknown = parser.parse_known_args()
+    else:
+        args = parser.parse_args()
+    return args
+
+
+if __name__ == "__main__":
+    args = parse_args(sys.argv[1:])
+
+    assert os.path.exists(args.file), f"file {args.file} does not exist"
+
+    extend_motpars(args.file, args.outfile)

--- a/scripts/preprocess.py
+++ b/scripts/preprocess.py
@@ -287,7 +287,6 @@ def process_fly(args):
             'basedir': args.basedir,
             'dir': args.process,
             'time_hours': 8 if args.partition == 'normal' else 24,
-            'stepsize': 4,
             'cores': min(
                 args.cores,
                 8 if args.partition == 'normal' else 4,


### PR DESCRIPTION
This branch was meant to address #7, but in the process of doing that I realized that the parameters generated by the motion_correction workflow were totally screwed up by the use of a nonstandard prefix for the transform files.  I ended up changing the model to use the single-timepoint registration (like @lukebrez had originally done), and then to apply the transforms for each timepoint, so that I can then delete the transform files to prevent them from filling up the /tmp directory on the compute nodes.  It has been tested on the test dataset and appears to work properly.  